### PR TITLE
updated min version for as aws-sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "archiver": "0.21.*",
     "async": "1.5.*",
-    "aws-sdk": "2.2.*",
+    "aws-sdk": "^2.437.0",
     "s3": "latest"
   },
   "repository": "https://github.com/DanielHindi/aws-s3-zipper.git",


### PR DESCRIPTION
Upgrade of aws-sdk as the older version 2.2 seems to have problems with instance profile

